### PR TITLE
docs(README): corrects dependency URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ allprojects {
 2. Add the dependency in your app's build.gradle file:
 ```
 dependencies {
-    implementation 'com.github.Mindinventory:circularslider:X.X.X'
+    implementation 'com.github.Mindinventory:AndroidCircularSlider:X.X.X'
 }
 ```
 3. Use this code inside your composable:


### PR DESCRIPTION
The previous one does not work so importing the app wasn't working (at least, not for me). I checked the jitpick.io badge and saw the URL in this change is the correct URL